### PR TITLE
README: Fix group_size location in params

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,9 @@ params = {
   options: {
     timestamps: true,
     unique: true,
-    check_for_existing: true,
-    group_size: 2_000
+    check_for_existing: true
   },
+  group_size: 2_000,
   variable_column: 'user_id',
   values: user_ids
 }


### PR DESCRIPTION
It's shown in `options` but should actually be in the root `params`