### PR TITLE
Allow empty static columns + allow columns checked for check_for_existing to be specified

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ rvm:
   - 2.5.3
   - 2.6.2
   - ruby-head
+services:
+  - mysql
+  - postgresql
 env:
   matrix:
     - DB=pg

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ sudo: required
 notifications:
   email: false
 rvm:
-  - 2.4.5
-  - 2.5.3
-  - 2.6.2
+  - 2.5.8
+  - 2.6.6
+  - 2.7.1
   - ruby-head
 services:
   - mysql

--- a/README.md
+++ b/README.md
@@ -85,7 +85,12 @@ Ensures that the 'values' parameter is a unique set of values. Default is false.
 
 ### check_for_existing
 
-Queries the table for any values which already exist and removes them from the values to be inserted. This query uses 'static_columns' and 'variable_column' for determining uniqueness. Default is false.
+Queries the table for any values which already exist and removes them from the values to be inserted. This query uses 'static_columns' and 'variable_column' for determining uniqueness unless the `check_existing_columns` option is specified. Default is false.
+
+### check_existing_columns
+
+When the `check_for_existing` option is `true`, specify an array of column names to use for the existing values check instead of the
+default behavior of checking all static columns plus variable columns.
 
 ### group_size
 

--- a/fast_inserter.gemspec
+++ b/fast_inserter.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
 
   case ENV['DB']
   when "mysql"; spec.add_development_dependency "mysql2"
-  when "sqlite"; spec.add_development_dependency "sqlite3", "~> 1.3.6"
+  when "sqlite"; spec.add_development_dependency "sqlite3"
   when "pg"; spec.add_development_dependency "pg"
   else spec.add_development_dependency "sqlite3" # Default
   end

--- a/spec/fast_inserter_base_spec.rb
+++ b/spec/fast_inserter_base_spec.rb
@@ -64,6 +64,29 @@ describe FastInserter do
       expect(event.attendees.find_by(user_id: 4).checked_in).to eq false
     end
 
+    it 'supports inserts without any static columns' do
+      event_names = [
+        'Test event',
+        'Another test event',
+        'Yet another test event',
+        'And one more test event'
+      ]
+
+      event_params = {
+        table: 'events',
+        variable_column: 'name',
+        values: event_names,
+        options: {
+          timestamps: true
+        }
+      }
+      inserter = FastInserter::Base.new(event_params)
+      expect(Event.count).to eq 0
+      inserter.fast_insert
+
+      expect(Event.all.pluck(:name)).to match_array event_names
+    end
+
     it "only inserts unique values when unique option is set" do
       mass_email = create_mass_email
       fake_email_addresses = ["student@amaranta.edu", "recruiter@fb.com", "recruiter@fb.com"]


### PR DESCRIPTION
There are two changes here, the first is to allow for inserts without any static columns. This is a fairly straightforward change, updating every place the static columns are used to allow them to be empty. I added one new spec to test this case.

The second change adds a new `check_existing_columns` option to be used with `check_for_existing`. This option takes an array of column names and uses only those columns for the check for existing records in the table, instead of using all of the static plus variable columns.  This required changes in many places in the code, unfortunately.

I added three new specs to test this. One to test when `check_existing_columns` includes both static and variable columns, one when it only includes variable column, and one when it only includes static columns (That case probably isn't very likely to happen with actual usage, but it's good to verify the behavior is consistent none the less.)